### PR TITLE
[FIX] Pop up modal fixes

### DIFF
--- a/styles-legacy/landing-page/im-excel.css
+++ b/styles-legacy/landing-page/im-excel.css
@@ -132,6 +132,30 @@ LANDING PAGE - EXCEL TEMPLATE
     padding:0;
 }
 
+/* Pop up on the blog posts - styling for hubspot - target:'' forms */
+
+.hubspot-modal--style { /* this is added to the same line as #form-modal */
+  padding-right: 32px;
+  max-width: 420px;
+  padding: 40px;
+  border-radius: 10px;
+  color: #fff;
+}
+
+/* Background colours for the pop up modals */
+
+.bg--ocean-blue {
+    background: #429bce;
+}
+
+.bg--vhs-blue {
+    background: #1c4561;
+}
+
+.bg--watermelon-red {
+    background: #f6574d;
+}
+
 /* excel landing page form style*/
 .excel-form .hs-error-msgs label{
     text-transform: initial;


### PR DESCRIPTION
**PROBLEM**

On random, Hubspot does this to our forms (appears all the way at the bottom, right above the footer):

![form-bottom](https://cloud.githubusercontent.com/assets/15664754/23984571/270d4192-0a55-11e7-93c3-048ad8cb53cd.png)

**SOLUTION**

Added some code on Hubspot's form module, and added some CSS to fix that. Now it looks like this:

![blue-popup](https://cloud.githubusercontent.com/assets/15664754/23984613/60543aa0-0a55-11e7-94ae-6cd2d6a0091b.png)



